### PR TITLE
Update wp 4.7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
             "package": {
                 "name": "wordpress",
                 "type": "webroot",
-                "version": "4.3.1",
+                "version": "4.7.2",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/WordPress/WordPress/archive/4.3.1.zip"
+                    "url": "https://github.com/WordPress/WordPress/archive/4.7.2.zip"
                 },
                 "require": {
                     "fancyguy/webroot-installer": "1.0.0"
@@ -36,7 +36,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "wordpress": "4.3.1",
+        "wordpress": "4.7.2",
         "fancyguy/webroot-installer": "1.0.0",
         "symfony/filesystem": "~2.7",
         "symfony/finder": "~2.7",

--- a/src/Wordpress/WPContent/themes/mgpress/lib/pages_setup.php
+++ b/src/Wordpress/WPContent/themes/mgpress/lib/pages_setup.php
@@ -42,16 +42,28 @@ class MgPageTemplates
         $this->templates = array();
 
         // Add a filter to the attributes metabox to inject template into the cache.
-        add_filter(
-            'page_attributes_dropdown_pages_args',
-            array($this, 'register_project_templates')
-        );
+        if ( version_compare( floatval( get_bloginfo( 'version' ) ), '4.7', '<' ) ) {
+
+            // 4.6 and older
+            add_filter(
+                'page_attributes_dropdown_pages_args',
+                array($this, 'register_project_templates')
+            );
+
+        } else {
+
+            // Add a filter to the wp 4.7 version attributes metabox
+            add_filter(
+                'theme_page_templates', array( $this, 'add_new_template' )
+            );
+
+        }
 
         add_filter(
             'default_page_template_title',
             array($this, 'register_project_templates')
         );
-        
+
         /** ACF Integration */
         add_action('acf/include_field_types', array($this, 'register_project_templates'));
 
@@ -75,6 +87,16 @@ class MgPageTemplates
         );
     }
 
+
+    /*
+     * Add custom templates for post/page/custom post types for WP 4.7+
+     */
+
+    public function add_new_template( $posts_templates ) {
+
+        $posts_templates = array_merge( $posts_templates, $this->loadCustomTemplates() );
+        return $posts_templates;
+    }
 
     /**
      * Adds our template to the pages cache in order to trick WordPress
@@ -107,6 +129,16 @@ class MgPageTemplates
 
         return $atts;
     }
+
+
+    /*
+     * Set list of custom templates
+     */
+    public function loadCustomTemplates(){
+        $templates = array();
+        return $templates;
+    }
+
 
     /**
      * Category Rewrite Filter

--- a/src/Wordpress/WPContent/themes/mgpress/lib/pages_setup.php
+++ b/src/Wordpress/WPContent/themes/mgpress/lib/pages_setup.php
@@ -42,16 +42,28 @@ class MgPageTemplates
         $this->templates = array();
 
         // Add a filter to the attributes metabox to inject template into the cache.
-        add_filter(
-            'page_attributes_dropdown_pages_args',
-            array($this, 'register_project_templates')
-        );
+        if ( version_compare( floatval( get_bloginfo( 'version' ) ), '4.7', '<' ) ) {
+
+            // 4.6 and older
+            add_filter(
+                'page_attributes_dropdown_pages_args',
+                array($this, 'register_project_templates')
+            );
+
+        } else {
+
+            // Add a filter to the wp 4.7 version attributes metabox
+            add_filter(
+                'theme_page_templates', array( $this, 'add_new_template' )
+            );
+
+        }
 
         add_filter(
             'default_page_template_title',
             array($this, 'register_project_templates')
         );
-        
+
         /** ACF Integration */
         add_action('acf/include_field_types', array($this, 'register_project_templates'));
 


### PR DESCRIPTION
update WordPress to version 4.7.2
 - WordPress 4.7 expanded the custom template feature for all Custom Post Types, with that, the  service hook that used to take care of it changed. 

Change list:
 - src/Wordpress/WPContent/themes/mgpress/lib/pages_setup.php
 - composer.json