### PR TITLE
Fix object as array issue

### DIFF
--- a/src/Mindgruve/MgPress/ComposerScripts.php
+++ b/src/Mindgruve/MgPress/ComposerScripts.php
@@ -63,10 +63,10 @@ class ComposerScripts
                 $name = $directory->getFilename();
                 if (in_array($name, $muPlugins)) {
                     $targetPath = __DIR__ . '/../../../src/Wordpress/WPContent/mu-plugins';
-                    $relPath = $fs->makePathRelative($directory, $targetPath);
+                    $relPath = $fs->makePathRelative((string)$directory, $targetPath);
                 } else {
                     $targetPath = __DIR__ . '/../../../src/Wordpress/WPContent/plugins';
-                    $relPath = $fs->makePathRelative($directory, $targetPath);
+                    $relPath = $fs->makePathRelative((string)$directory, $targetPath);
                 }
                 $fs->symlink($relPath, $targetPath . '/' . $name);
             }


### PR DESCRIPTION
Forcing first argument of FileSystem::makePathRelative() to be cast as string, otherwise object SplFileInfo was failing to be used as array.