### PR TITLE
Template load order for Front Page.

### DIFF
--- a/page.php
+++ b/page.php
@@ -40,14 +40,14 @@ if (post_password_required($post->ID)) {
         'index.twig'
     );
 
-    // add template if being used
-    if (!is_null($templateName)) {
-        array_unshift($templates, 'template/' . $templateName . '.twig');
-    }
-
     // site front page template
     if (is_front_page()) {
         array_unshift($templates, 'detail/front-page.twig');
+    }
+
+    // add template if being used
+    if (!is_null($templateName)) {
+        array_unshift($templates, 'template/' . $templateName . '.twig');
     }
 }
 


### PR DESCRIPTION
The front page template was taking over and the CMS selection and getting loaded before the selected template. 

This change will make the template selection have more weight over the front-page template load.

# Example: 
Having a custom home.twig template file under the right folder will allow the user to select that template from the cms. 

1 - Create a new custom template called home
2 - Create a new page on the CMS
3 - Select the custom home template created
4 - Make that page you front page

When you visualize the page, the view will be loaded  from the front-page view file and the template selection will be ignored.

This change will weight the selected custom template over the natural load order.